### PR TITLE
fix: bluesky post testで使う投稿内容例を修正

### DIFF
--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -1,5 +1,4 @@
 import os
-import random
 
 from app.models.bluesky_models import LabelEnum
 from app.settings.bluesky_settings import LIMIT_MESSAGE_LENGTH
@@ -56,7 +55,7 @@ def test_post_record():
         handle=TEST_HANDLE, app_password=TEST_APP_PASSWORD
     )
     assert login_response
-    text = f"test https://hito-horobe.net/ です{random.randint(1, 10)}"* 20
+    text = "test https://hito-horobe.net/ です"* 20
     link_to_tweet = "https://x.com/hito_horobe2/status/1801101262727037180"
     record = Bluesky.make_record(login_response, text, link_to_tweet)
     assert len(record.record.text) >= LIMIT_MESSAGE_LENGTH


### PR DESCRIPTION
## [Summary]
- pytest のbluesky への投稿テストの関数`test_post_record`で使う投稿文字列を修正する
## [Details]
- 同一投稿を連続すると投稿に失敗する可能性があると考え、テスト投稿の文字列にランダムな数字を付与していた
  - 実際は同一投稿が連続しても問題なかった
  - 検証を容易にするためランダムな数字を付与しない