### PR TITLE
fix: link_to_tweet を必須ではなくオプションに変更

### DIFF
--- a/app/models/ifttt_models.py
+++ b/app/models/ifttt_models.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,5 +11,5 @@ class IftttRequestBody(BaseModel):
     handle: str = Field(description="Blueskyのハンドル", examples=[TEST_HANDLE])
     app_password: str = Field(description="Blueskyのアプリパスワード", examples=[TEST_APP_PASSWORD])
     text: str = Field(description="投稿内容", examples=["test https://hito-horobe.net/ です"])
-    link_to_tweet: str = Field(description="ツイートへのリンクURL")
+    link_to_tweet: Optional[str] = Field(description="ツイートへのリンクURL", default=None, examples=[None])
 

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -168,7 +168,7 @@ class Bluesky:
 
 
     @classmethod
-    def make_record(cls, login_response: LoginResponse, text: str, link_to_tweet: str) -> CreateRecordPayload:
+    def make_record(cls, login_response: LoginResponse, text: str, link_to_tweet: Optional[str]=None) -> CreateRecordPayload:
         """
         新規ポスト用のペイロードを作成する
         - URLを抽出
@@ -244,15 +244,16 @@ class Bluesky:
             byte_start = get_byte_length(text)
             byte_end = byte_start + get_byte_length(link_text)
             text += link_text
-            facet = Facet(
-                index=Index(
-                    byte_start=byte_start,
-                    byte_end=byte_end
-                ), 
-                features=[
-                    Feature(types="app.bsky.richtext.facet#link", uri=HttpUrl(link_to_tweet)),
-                ])
-            facets.append(facet)
+            if link_to_tweet:
+                facet = Facet(
+                    index=Index(
+                        byte_start=byte_start,
+                        byte_end=byte_end
+                    ), 
+                    features=[
+                        Feature(types="app.bsky.richtext.facet#link", uri=HttpUrl(link_to_tweet)),
+                    ])
+                facets.append(facet)
 
         # Embed が存在し、かつリストの最後の要素がセンシティブリストに含まれるURLを持っている場合、
         # センシティブラベルを付与


### PR DESCRIPTION
## [Summary]
APIのリクエストボディで必須になっていた`link_to_tweet`をオプションに変更

## [Details]
現状ではX Premium等でツイートが300字を超えた場合、元ツイートへリンクを貼るようにしているが、  
以下の理由により`link_to_tweet`を設定したくない場合がある
- 非公開X/Twitterアカウントと連携しているケース
- IFTTTでX/Twitter以外と連携するケース（`link_to_tweet`に入れるべきものがない）
