### PR TITLE
fix: URL展開ルールを変更

### DIFF
--- a/app/utils/ogp_utils.py
+++ b/app/utils/ogp_utils.py
@@ -63,7 +63,7 @@ def get_ogp(url: str) -> Optional[OGP]:
 
     # if x.com or twitter.com -> use requests
     if url.find("x.com") != -1 or url.find("twitter.com") != -1:
-        user_agent = "facebookexternalhit"
+        user_agent = "facebookexternalhit/1.1"
         return _get_ogp_from_requests(url, user_agent)
     #elif url.find("amazon.co.jp") != -1:
     #    user_agent = "facebookexternalhit"

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -44,7 +44,7 @@ def test_make_record():
         handle=TEST_HANDLE, app_password=TEST_APP_PASSWORD
     )
     assert login_response
-    text = "test https://hito-horobe.net/ です"
+    text = "ハヤカワの書籍が半額になる「早川書房 夏のKindle超ビッグセール」が開催されてる！去年よりラインナップが大幅に増えて3000冊以上が対象、『プロジェクト・ヘイル・メアリー』ほか https://t.co/llBEMgzMlx #ad https://t.co/BfZI5kTpvq"
     link_to_tweet = "https://x.com/hito_horobe2/status/1801101262727037180"
     record = Bluesky.make_record(login_response, text, link_to_tweet)
     assert record

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -44,7 +44,7 @@ def test_make_record():
         handle=TEST_HANDLE, app_password=TEST_APP_PASSWORD
     )
     assert login_response
-    text = "ハヤカワの書籍が半額になる「早川書房 夏のKindle超ビッグセール」が開催されてる！去年よりラインナップが大幅に増えて3000冊以上が対象、『プロジェクト・ヘイル・メアリー』ほか https://t.co/llBEMgzMlx #ad https://t.co/BfZI5kTpvq"
+    text = "test https://hito-horobe.net/ です"
     link_to_tweet = "https://x.com/hito_horobe2/status/1801101262727037180"
     record = Bluesky.make_record(login_response, text, link_to_tweet)
     assert record

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -9,3 +9,21 @@ def test_get_ogp():
     assert ogp.description
     assert ogp.image
     assert ogp.url
+
+
+def test_get_ogp_twitter():
+    # TwitteからOGPを取得する
+    url = "https://x.com/hito_horobe2/status/1805572107662934083"
+    ogp = get_ogp(url)
+    # 以前は画像が取得できたが、今はできずタイトルとサイト名しか取れない
+    assert ogp.title
+    assert ogp.site_name
+
+
+def test_get_opg_error():
+    # 存在しないURLの場合はNoneを返す
+    url = "https://notexist.url/"
+    ogp = get_ogp(url)
+    assert ogp is None
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,13 @@ def test_expand_url_amazon():
     assert expanded_url == "https://amzn.to/3RFJ2HN"
 
 
+def test_expand_url_twitter():
+    # TwitterのURLをx.comになるまで再帰的に展開する
+    original_url = "https://t.co/BfZI5kTpvq"
+    expanded_url = expand_url(original_url)
+    assert expanded_url == "https://x.com/hito_horobe2/status/1805572107662934083"
+
+
 def test_ommit_long_url():
     # URLを省略表示する
     url = "https://ja.wikipedia.org/wiki/GitHub"


### PR DESCRIPTION
## [Summary]
URLを展開する時、次のルールにする
- `amzn.to`: 展開しない
- `bit.ly`: 展開しない
- `twitter.com`: `x.com`へ転送したURLを返す
- `x.com`のメディア付きリンク: 末尾の`/photo/1`を削除
- それ以外: 再帰的に展開して展開後のリンクを返す

## [Details]
以下の理由による
- TwitterのOGPの仕様変更
  - twitter.comからOGPが取れない。x.comからは取れる時がある（？）
  - 今までは`t.co`を展開して`twitter.com`だったらそのまま返していたが、今後twiter.comからx.comへリダイレクトされなくなる可能性がある
- OGP画像のポルノ、センシティブの判定のためにリンク展開を行う

以下の影響範囲も変更する
- url展開関連のテスト
- ogp関連のテスト