### PR TITLE
fix: bluesky の pytest を mock化

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -907,6 +907,23 @@ pluggy = ">=1.5,<2.0"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1557,4 +1574,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <3.13"
-content-hash = "db350ca7fd1c467145d3e162827139e8a22d0ffd25dd88b4847cda9e77f8122f"
+content-hash = "308921276a994c6daed615cbac269b862b7cdec895008f66a0d2b323e68fd681"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pydantic = "^2.7.4"
 requests = "^2.32.3"
 bs4 = "^0.0.2"
 requests-cache = "^1.2.1"
+pytest-mock = "^3.14.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
## [Summary]
- pytest の bluesky 周辺のテストにおいて実際にログインならびにポストして試していたが、blueskyにおいては非公開アカウント等がなくすべて公開されてしまう
- mockを使うほうがよい

## [Details]
- ログイン、画像アップロードをmock化
- レコードを作成して型を検証するところで終わり、実際の投稿は行わない