### PR TITLE
feature: uvicorn内部のloggerと統合したログ出力を追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ ENV=local
 TEST_HANDLE={テスト用アカウントのハンドル}
 TEST_APP_PASSWORD={テスト用アカウントのAPP_PASSWORD}
 CLIENT_NAME={via欄に表示するクライアント名}
+LOG_LEVEL="INFO"

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -42,7 +42,7 @@ from app.settings.sensitive_url_list import PORN_URL_LIST
 from app.utils.ogp_utils import get_ogp
 from app.utils.url_utils import expand_url, extract_url, get_byte_length, ommit_long_url
 
-logger = getLogger(__name__)
+logger = getLogger("uvicorn.app")
 requests_cache.install_cache("bluesky_cache", backend="sqlite", expire_after=300)
 CLIENT_NAME = os.getenv("CLIENT_NAME", DEFAULT_CLIENT_NAME)
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from app.router import root_api_router
 
 env = os.getenv("ENV", "local")
-logger = getLogger(__name__)
+logger = getLogger("uvicorn.app")
 
 if env == "local":
     app = FastAPI()


### PR DESCRIPTION
## [Summary]
#64 の実装
- スパム対策等でログを出力する
- logging と uvicorn のログを統合する

## [Details]
- ログのサンプル
```
ifttt_to_bluesky_api  | ログインに失敗しました。ハンドルまたはパスワードを確認してください
ifttt_to_bluesky_api  | ERROR:    ログインに失敗しました。ハンドルまたはパスワードを確認してください
ifttt_to_bluesky_api  | INFO:     172.27.0.1:46398 - "POST /twitter_to_bluesky HTTP/1.1" 400 Bad Request
ifttt_to_bluesky_api  | INFO:     record: repo='did:plc:bb3uuzvbxspko5sheie67vw7' collection='app.bsky.feed.post' record=Record(text='_', created_at='2024-11-20T17:39:39.503854+09:00', facets=[], types='app.bsky.feed.post', embed=None, labels=None, via='twitter-ifttt-bluesky by @hito-horobe.net')
ifttt_to_bluesky_api  | INFO:     172.27.0.1:52710 - "POST /twitter_to_bluesky HTTP/1.1" 200 OK
```