### PR TITLE
fix: OGP取得処理中に例外が発生した場合に処理を止めずNoneを返す

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,4 @@ TEST_HANDLE={テスト用アカウントのハンドル}
 TEST_APP_PASSWORD={テスト用アカウントのAPP_PASSWORD}
 CLIENT_NAME={via欄に表示するクライアント名}
 LOG_LEVEL="INFO"
+OGP_REQUEST_TIMEOUT=30

--- a/app/settings/bluesky_settings.py
+++ b/app/settings/bluesky_settings.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta, timezone
 
 BLUESKY_API_DOMAIN = os.getenv("BLUESKY_DOMAIN_NAME", "bsky.social")
+BLUESKY_REQUEST_TIMEOUT = int(os.getenv("BLUESKY_REQUEST_TIMEOUT", 30))
 TZ = timezone(timedelta(hours=+9), "JST")
 LIMIT_MESSAGE_LENGTH = 300
 DEFAULT_CLIENT_NAME = "twitter-ifttt-bluesky by @hito-horobe.net"

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -34,6 +34,7 @@ from app.models.exception_models import (
 )
 from app.settings.bluesky_settings import (
     BLUESKY_API_DOMAIN,
+    BLUESKY_REQUEST_TIMEOUT,
     DEFAULT_CLIENT_NAME,
     LIMIT_MESSAGE_LENGTH,
     TZ,
@@ -81,7 +82,10 @@ class Bluesky:
 
         try:
             response = requests.post(
-                login_endpoint, data=payload, headers=headers, timeout=10
+                login_endpoint,
+                data=payload,
+                headers=headers,
+                timeout=BLUESKY_REQUEST_TIMEOUT,
             )
             if response.status_code != 200:
                 raise LoginError
@@ -132,7 +136,7 @@ class Bluesky:
         # ウェブサイト側の設定ミスで指定されているリンクから画像が取得できない場合があるため、
         # その場合は例外で停止させず None を返す
         try:
-            image_response = requests.get(image_url, timeout=10)
+            image_response = requests.get(image_url, timeout=BLUESKY_REQUEST_TIMEOUT)
 
         except Exception as e:
             logger.error(e)
@@ -148,7 +152,10 @@ class Bluesky:
         }
         try:
             response = requests.post(
-                image_endpoiiint, data=blobs, headers=headers, timeout=10
+                image_endpoiiint,
+                data=blobs,
+                headers=headers,
+                timeout=BLUESKY_REQUEST_TIMEOUT,
             )
 
             response_obj = json.loads(response.text)
@@ -323,7 +330,7 @@ class Bluesky:
                 post_endpoint,
                 data=record.model_dump_json(by_alias=True, exclude_none=True),
                 headers=headers,
-                timeout=10,
+                timeout=BLUESKY_REQUEST_TIMEOUT,
             )
             return record
 

--- a/app/utils/ogp_utils.py
+++ b/app/utils/ogp_utils.py
@@ -7,6 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from app.models.ogp_models import OGP
+from app.settings.bluesky_settings import BLUESKY_REQUEST_TIMEOUT
 
 
 log_level = os.getenv("LOG_LEVEL", "INFO")
@@ -18,7 +19,7 @@ def _get_ogp_from_requests(url: str, user_agent: str) -> Optional[OGP]:
     """Retrieve OGP using requests"""
     headers = {"User-Agent": user_agent}
     try:
-        response = requests.get(url, headers=headers, timeout=10)
+        response = requests.get(url, headers=headers, timeout=BLUESKY_REQUEST_TIMEOUT)
 
         if response.status_code != 200:
             return None
@@ -54,7 +55,9 @@ def _get_ogp_from_bluesky(url: str, user_agent: str) -> Optional[OGP]:
     headers = {"User-Agent": user_agent}
     request_url = f"https://cardyb.bsky.app/v1/extract?url={url}"
     try:
-        response = requests.get(request_url, headers=headers, timeout=10)
+        response = requests.get(
+            request_url, headers=headers, timeout=BLUESKY_REQUEST_TIMEOUT
+        )
         if response.status_code != 200:
             return None
 

--- a/app/utils/ogp_utils.py
+++ b/app/utils/ogp_utils.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 from logging import getLogger
 from typing import Optional
 
@@ -8,7 +8,6 @@ from bs4 import BeautifulSoup
 
 from app.models.ogp_models import OGP
 from app.settings.bluesky_settings import BLUESKY_REQUEST_TIMEOUT
-
 
 log_level = os.getenv("LOG_LEVEL", "INFO")
 logger = getLogger("uvicorn.app")

--- a/app/utils/ogp_utils.py
+++ b/app/utils/ogp_utils.py
@@ -1,4 +1,6 @@
+import os
 import json
+from logging import getLogger
 from typing import Optional
 
 import requests
@@ -7,34 +9,43 @@ from bs4 import BeautifulSoup
 from app.models.ogp_models import OGP
 
 
+log_level = os.getenv("LOG_LEVEL", "INFO")
+logger = getLogger("uvicorn.app")
+logger.setLevel(log_level)
+
+
 def _get_ogp_from_requests(url: str, user_agent: str) -> Optional[OGP]:
     """Retrieve OGP using requests"""
     headers = {"User-Agent": user_agent}
-    response = requests.get(url, headers=headers, timeout=10)
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
 
-    if response.status_code != 200:
-        return None
+        if response.status_code != 200:
+            return None
 
-    soup = BeautifulSoup(response.text, "html.parser")
+        soup = BeautifulSoup(response.text, "html.parser")
 
-    og_title = soup.find("meta", attrs={"property": "og:title"})
-    og_description = soup.find("meta", attrs={"name": "description"})
-    og_image = soup.find("meta", attrs={"property": "og:image"})
-    og_url = soup.find("meta", attrs={"property": "og:url"})
-    og_site_name = soup.find("meta", attrs={"property": "og:site_name"})
-    og_type = soup.find("meta", attrs={"property": "og:type"})
+        og_title = soup.find("meta", attrs={"property": "og:title"})
+        og_description = soup.find("meta", attrs={"name": "description"})
+        og_image = soup.find("meta", attrs={"property": "og:image"})
+        og_url = soup.find("meta", attrs={"property": "og:url"})
+        og_site_name = soup.find("meta", attrs={"property": "og:site_name"})
+        og_type = soup.find("meta", attrs={"property": "og:type"})
 
-    if og_title or og_description or og_image or og_url or og_site_name or og_type:
-        ogp = OGP(
-            title=og_title.get("content") if og_title else None, # type: ignore
-            description=og_description.get("content") if og_description else None, # type: ignore
-            image=og_image.get("content") if og_image else None, # type: ignore
-            url=og_url.get("content") if og_url else None, # type: ignore
-            site_name=og_site_name.get("content") if og_site_name else None, # type: ignore
-            type=og_type.get("content") if og_type else None, # type: ignore
-        )
-        return ogp
-    else:
+        if og_title or og_description or og_image or og_url or og_site_name or og_type:
+            ogp = OGP(
+                title=og_title.get("content") if og_title else None,  # type: ignore
+                description=og_description.get("content") if og_description else None,  # type: ignore
+                image=og_image.get("content") if og_image else None,  # type: ignore
+                url=og_url.get("content") if og_url else None,  # type: ignore
+                site_name=og_site_name.get("content") if og_site_name else None,  # type: ignore
+                type=og_type.get("content") if og_type else None,  # type: ignore
+            )
+            return ogp
+        else:
+            return None
+    except Exception as e:
+        logger.error(e)
         return None
 
 
@@ -42,20 +53,24 @@ def _get_ogp_from_bluesky(url: str, user_agent: str) -> Optional[OGP]:
     """Retrieve OGP using cardyb.bsky.app"""
     headers = {"User-Agent": user_agent}
     request_url = f"https://cardyb.bsky.app/v1/extract?url={url}"
-    response = requests.get(request_url, headers=headers, timeout=10)
-    if response.status_code != 200:
-        return None
+    try:
+        response = requests.get(request_url, headers=headers, timeout=10)
+        if response.status_code != 200:
+            return None
 
-    response_obj = json.loads(response.text)
-    if response_obj["error"]:
-        return None
+        response_obj = json.loads(response.text)
+        if response_obj["error"]:
+            return None
 
-    return OGP(
-        title=response_obj["title"],
-        description=response_obj["description"],
-        image=response_obj["image"] if response_obj["image"] else None,
-        url=response_obj["url"] if response_obj["url"] else None,
-    )
+        return OGP(
+            title=response_obj["title"],
+            description=response_obj["description"],
+            image=response_obj["image"] if response_obj["image"] else None,
+            url=response_obj["url"] if response_obj["url"] else None,
+        )
+    except Exception as e:
+        logger.error(e)
+        return None
 
 
 def get_ogp(url: str) -> Optional[OGP]:
@@ -65,7 +80,7 @@ def get_ogp(url: str) -> Optional[OGP]:
     if url.find("x.com") != -1 or url.find("twitter.com") != -1:
         user_agent = "facebookexternalhit/1.1"
         return _get_ogp_from_requests(url, user_agent)
-    #elif url.find("amazon.co.jp") != -1:
+    # elif url.find("amazon.co.jp") != -1:
     #    user_agent = "facebookexternalhit"
     #    return _get_ogp_from_requests(url, user_agent)
     else:

--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -4,6 +4,7 @@ import requests
 
 from app.models.bluesky_models import LabelEnum
 from app.utils.ogp_utils import get_ogp
+from app.settings.bluesky_settings import BLUESKY_REQUEST_TIMEOUT
 
 
 def extract_url(text: str) -> list[str]:
@@ -28,7 +29,9 @@ def expand_url(url: str) -> str:
             return url
         if "https://bit.ly" in url:
             return url
-        response = requests.get(url, timeout=10, headers=headers, allow_redirects=False)
+        response = requests.get(
+            url, timeout=BLUESKY_REQUEST_TIMEOUT, headers=headers, allow_redirects=False
+        )
         if 300 <= response.status_code < 400:
             return expand_url(response.headers["Location"])
         else:
@@ -46,7 +49,7 @@ def ommit_long_url(url: str, length=32) -> str:
     ただし、入力した文字列が32文字以下の場合はそのまま返す
     """
     if len(url) > length:
-        return url[:length-3] + "..."
+        return url[: length - 3] + "..."
     return url
 
 

--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -3,8 +3,8 @@ import re
 import requests
 
 from app.models.bluesky_models import LabelEnum
-from app.utils.ogp_utils import get_ogp
 from app.settings.bluesky_settings import BLUESKY_REQUEST_TIMEOUT
+from app.utils.ogp_utils import get_ogp
 
 
 def extract_url(text: str) -> list[str]:


### PR DESCRIPTION
## [Summary]
- クロスポスト処理時、OGP取得処理中に requests のタイムアウト等のエラーが起きると例外で中断されてしまい、クロスポスト全体の処理が行われない問題があった
- bluesky のユーザ増大でOGP取得APIがよくエラーになる
- OGPの取得処理に失敗した場合はNoneを返し、処理を続行してクロスポストを成功させたい

## [Details]
- ステータスコードに応じた処理 + try-except によるエラーハンドリングを追加
- エラーログの出力
- タイムアウト時間をマジックナンバーでなく定数化し、環境変数でも変更可能とする
  - Bluesky側の状況を見て調整したい