### PR TITLE
feature: ハッシュタグ機能を実装

### DIFF
--- a/app/models/bluesky_models.py
+++ b/app/models/bluesky_models.py
@@ -24,7 +24,8 @@ class Feature(BaseModel):
     types: str = Field(
         serialization_alias="$type", default="app.bsky.richtext.facet#link"
     )
-    uri: HttpUrl
+    uri: Optional[HttpUrl] = None
+    tag: Optional[str] = None
 
 
 class Facet(BaseModel):

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -268,7 +268,8 @@ class Bluesky:
                         features=[
                             Feature(
                                 types="app.bsky.richtext.facet#tag",
-                                tag=hashtag,
+                                # ハッシュタグの先頭の#を削除
+                                tag=re.sub(r"^#", "", hashtag),
                             ),
                         ],
                     )

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -46,10 +46,10 @@ from app.settings.sensitive_url_list import PORN_URL_LIST
 from app.utils.ogp_utils import get_ogp
 from app.utils.url_utils import (
     expand_url,
+    extract_hashtags,
     extract_url,
     get_byte_length,
     ommit_long_url,
-    extract_hashtags,
 )
 
 logger = getLogger("uvicorn.app")

--- a/app/utils/bluesky_utils.py
+++ b/app/utils/bluesky_utils.py
@@ -44,7 +44,13 @@ from app.settings.bluesky_settings import (
 )
 from app.settings.sensitive_url_list import PORN_URL_LIST
 from app.utils.ogp_utils import get_ogp
-from app.utils.url_utils import expand_url, extract_url, get_byte_length, ommit_long_url
+from app.utils.url_utils import (
+    expand_url,
+    extract_url,
+    get_byte_length,
+    ommit_long_url,
+    extract_hashtags,
+)
 
 logger = getLogger("uvicorn.app")
 requests_cache.install_cache("bluesky_cache", backend="sqlite", expire_after=300)
@@ -238,9 +244,35 @@ class Bluesky:
         """
 
         urls = extract_url(text)
+        hashtags = extract_hashtags(text)
         facets: list[Facet] = []
         embed: list[Embed] = []
         labels = None
+
+        # 重複するハッシュタグを削除
+        hashtags = list(dict.fromkeys(hashtags))
+        for hashtag in hashtags:
+            matched_all = re.finditer(re.escape(hashtag), text)
+            # リッチテキストでハッシュタグを表現する
+            # 終了位置が文字数上限を超えている場合はリッチテキストを作成しない
+            for matched in matched_all:
+                if matched.end() > LIMIT_MESSAGE_LENGTH:
+                    continue
+                else:
+                    start_string = matched.start()
+                    byte_start = get_byte_length(text[:start_string])
+                    byte_end = byte_start + get_byte_length(hashtag)
+
+                    facet = Facet(
+                        index=Index(byte_start=byte_start, byte_end=byte_end),
+                        features=[
+                            Feature(
+                                types="app.bsky.richtext.facet#tag",
+                                tag=hashtag,
+                            ),
+                        ],
+                    )
+                    facets.append(facet)
 
         # 重複するURLを削除
         urls = list(dict.fromkeys(urls))

--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -53,6 +53,19 @@ def ommit_long_url(url: str, length=32) -> str:
     return url
 
 
+def extract_hashtags(text: str) -> list[str]:
+    """入力した文字列の中からハッシュタグを全て抜粋してリストで返す
+    ただし、url anchor(文中に#がついているもの)は除外する
+    """
+    hashtags = []
+    # urlを全て除外
+    for url in extract_url(text):
+        text = text.replace(url, "")
+    for hashtag in re.findall(r"#\S+", text):
+        hashtags.append(hashtag)
+    return hashtags
+
+
 def get_byte_length(text: str) -> int:
     """入力した文字列のバイト長を返す"""
     return len(text.encode("utf-8"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 from app.utils.url_utils import (
     expand_url,
+    extract_hashtags,
     extract_url,
     ommit_long_url,
-    extract_hashtags,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,9 @@
-from app.utils.url_utils import expand_url, extract_url, ommit_long_url
+from app.utils.url_utils import (
+    expand_url,
+    extract_url,
+    ommit_long_url,
+    extract_hashtags,
+)
 
 
 def test_extract_url():
@@ -44,6 +49,25 @@ def test_ommit_long_url_short():
     url = "https://x.com/"
     omitted_url = ommit_long_url(url)
     assert omitted_url == url
+
+
+def test_extract_hashtags():
+    # テキストからハッシュタグを抽出する
+    text = "これはテストです。#テスト #Python #GitHub"
+    hashtags = extract_hashtags(text)
+    assert hashtags == ["#テスト", "#Python", "#GitHub"]
+    text2 = "これはハッシュタグを含まないテキストです https://example.com#top"
+    hashtags2 = extract_hashtags(text2)
+    assert hashtags2 == []
+    text3 = "#ハッシュタグ これはハッシュタグが文頭のパターン"
+    hashtags3 = extract_hashtags(text3)
+    assert hashtags3 == ["#ハッシュタグ"]
+    text4 = "これはハッシュタグが文末のパターン #ハッシュタグ"
+    hashtags4 = extract_hashtags(text4)
+    assert hashtags4 == ["#ハッシュタグ"]
+    text5 = "これは改行後にハッシュタグがあるパターン\n#ハッシュタグ"
+    hashtags5 = extract_hashtags(text5)
+    assert hashtags5 == ["#ハッシュタグ"]
 
 
 def get_byte_length():


### PR DESCRIPTION
close #72 

## [Summary]
- ハッシュタグを実装

## [Details]
- ハッシュタグの判定方法
  - #で始まり空白文字以外が1文字以上連続する文字列を全て抜粋し、ハッシュタグと判定する
  - URLアンカー (https://example.com#anchor のような形式) はハッシュタグと判定しない

- レコードの形式
  - facets モデルを改修してリンクだけでなくハッシュタグも対応可能にする
```
{
	"facets": [
		{
			"$type": "app.bsky.richtext.facet",
			"features": [
				{
					"$type": "app.bsky.richtext.facet#tag",
					"tag": "shindanmaker"
				}
			],
			"index": {
				"byteEnd": 256,
				"byteStart": 243
			}
		}
	]
}
```