### PR TITLE
fix: DMMのアフィリエイトリンクを展開しない

### DIFF
--- a/app/settings/sensitive_url_list.py
+++ b/app/settings/sensitive_url_list.py
@@ -2,6 +2,8 @@ PORN_URL_LIST = [
     "www.dlsite.com",
     "www.dmm.co.jp",
     "www.dmm.com",
+    "al.dmm.co.jp",
+    "al.dmm.com",
     "xvideos.com",
     "pornhub.com",
     "xhamster.com",

--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -19,6 +19,7 @@ def expand_url(url: str) -> str:
     """入力したURLを展開して返す。OGPの有無によって、次の挙動をする
     - amzn.to: そのまま返す
     - bit.ly: そのまま返す
+    - al.dmm.com: そのまま返す
     - twitter.com または x.com で末尾に/photo/1を含む場合: 末尾の/photo/1を削除して返す
     - それ以外: 展開が完了するまで再帰的に処理し、展開後のURLを返す
     """
@@ -28,6 +29,8 @@ def expand_url(url: str) -> str:
         if "https://amzn.to" in url:
             return url
         if "https://bit.ly" in url:
+            return url
+        if "https://al.dmm.com" in url:
             return url
         response = requests.get(
             url, timeout=BLUESKY_REQUEST_TIMEOUT, headers=headers, allow_redirects=False

--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -20,6 +20,7 @@ def expand_url(url: str) -> str:
     - amzn.to: そのまま返す
     - bit.ly: そのまま返す
     - al.dmm.com: そのまま返す
+    - al.dmm.co.jp: そのまま返す
     - twitter.com または x.com で末尾に/photo/1を含む場合: 末尾の/photo/1を削除して返す
     - それ以外: 展開が完了するまで再帰的に処理し、展開後のURLを返す
     """
@@ -31,6 +32,8 @@ def expand_url(url: str) -> str:
         if "https://bit.ly" in url:
             return url
         if "https://al.dmm.com" in url:
+            return url
+        if "https://al.dmm.co.jp" in url:
             return url
         response = requests.get(
             url, timeout=BLUESKY_REQUEST_TIMEOUT, headers=headers, allow_redirects=False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,16 @@ def test_expand_url_twitter():
     assert expanded_url == "https://x.com/hito_horobe2/status/1805572107662934083"
 
 
-def test_expand_url_al_dmm():
-    # DMMのURLは展開しない
+def test_expand_url_al_dmm_com():
+    # DMM.comのアフィリエイトURLは展開しない
     original_url = "https://al.dmm.com/?lurl=https%3A%2F%2Fbook.dmm.com%2F&af_id=dmmg-001&ch=toolbar&ch_id=link"
+    expanded_url = expand_url(original_url)
+    assert expanded_url == original_url
+
+
+def test_expand_url_al_dmm_co_jp():
+    # DMM.co.jpのアフィリエイトURLは展開しない
+    original_url = "https://al.dmm.co.jp/?lurl=https%3A%2F%2Fwww.dmm.co.jp%2Fdc%2Fdoujin%2F&af_id=dmmg-001&ch=toolbar&ch_id=link"
     expanded_url = expand_url(original_url)
     assert expanded_url == original_url
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,13 @@ def test_expand_url_twitter():
     assert expanded_url == "https://x.com/hito_horobe2/status/1805572107662934083"
 
 
+def test_expand_url_al_dmm():
+    # DMMのURLは展開しない
+    original_url = "https://al.dmm.com/?lurl=https%3A%2F%2Fbook.dmm.com%2F&af_id=dmmg-001&ch=toolbar&ch_id=link"
+    expanded_url = expand_url(original_url)
+    assert expanded_url == original_url
+
+
 def test_ommit_long_url():
     # URLを省略表示する
     url = "https://ja.wikipedia.org/wiki/GitHub"


### PR DESCRIPTION
https://github.com/hitohorobe/twitter-ifttt-bluesky/issues/111 の修正

## 概要
- DMMのアフィリエイトリンクはal.dmm.com または al.dmm.co,jp
- 展開されるとアフィリエイトリンクとして機能しない
- 展開しないようにする

## 対応
- 展開しないようにする
- センシティブ判定URLリストを更新する