### PR TITLE
fix: URL展開時にリダイレクトされたURLが相対パスの場合にフルパスに直すよう修正

### DIFF
--- a/app/utils/url_utils.py
+++ b/app/utils/url_utils.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urljoin
 
 import requests
 
@@ -45,7 +46,8 @@ def expand_url(url: str) -> str:
             url, timeout=BLUESKY_REQUEST_TIMEOUT, headers=headers, allow_redirects=False
         )
         if 300 <= response.status_code < 400:
-            return expand_url(response.headers["Location"])
+            location = urljoin(url, response.headers["Location"])
+            return expand_url(location)
         else:
             if "twitter.com" in url or "x.com" in url:
                 if "/photo/1" in url:

--- a/uv.lock
+++ b/uv.lock
@@ -602,13 +602,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bs4", specifier = ">=0.0.2,<0.0.3" },
-    { name = "fastapi", specifier = ">=0.135.1,<0.138" },
+    { name = "fastapi", specifier = ">=0.135.1,<0.140" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "pillow", specifier = ">=12.1.1,<13" },
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "requests-cache", specifier = ">=1.2.1,<2" },
-    { name = "uvicorn", specifier = ">=0.41.0,<0.50" },
+    { name = "uvicorn", specifier = ">=0.41.0,<0.51" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
close #244 

- URL展開時の転送前に相対パスを絶対パスに直す
- uvの更新